### PR TITLE
#20135 Proposed Fix

### DIFF
--- a/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoProperties.java
+++ b/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/buildinfo/BuildInfoProperties.java
@@ -48,6 +48,10 @@ public class BuildInfoProperties implements Serializable {
 
 	BuildInfoProperties(Project project) {
 		this.project = project;
+		//Default the properties:
+		this.group = project.getGroup().toString();
+		this.name = project.getName();
+		this.version = project.getVersion().toString();
 		this.time = Instant.now();
 	}
 


### PR DESCRIPTION
Default the properties in the constructor. If the version, name or group properties are unchanged, then the hashcode/equals/serialization should all work correctly. 
Fixes #20135
